### PR TITLE
Improved whitespaces

### DIFF
--- a/Items.g4
+++ b/Items.g4
@@ -1,5 +1,9 @@
 grammar Items;
 
+itemmodel :
+	(NEWLINE* (modelitem) (NEWLINE | modelitem)*) EOF
+;
+
 modelitem :
 	(basemodelitem | modelgroupitem) WHITESPACE+ IDENTIFIER
 	(WHITESPACE+ STRING)?
@@ -11,10 +15,6 @@ modelitem :
 
 modelgroupitem :
 	'Group' (':' basemodelitem ( ':' modelgroupfunction ('(' (IDENTIFIER|STRING) (',' (IDENTIFIER|STRING))* ')')?)?)?
-;
-
-itemmodel :
-	(NEWLINE* modelitem (NEWLINE | itemmodel)*) EOF
 ;
 
 basemodelitem 

--- a/Items.g4
+++ b/Items.g4
@@ -1,28 +1,43 @@
 grammar Items;
 
 modelitem :
-	(basemodelitem | modelgroupitem) WHITESPACE IDENTIFIER
-	(WHITESPACE STRING)?
-	(WHITESPACE '<' (IDENTIFIER|STRING) '>')?
-	(WHITESPACE '(' IDENTIFIER (',' IDENTIFIER)* ')')? 
-	(WHITESPACE '[' (IDENTIFIER|STRING) (',' (IDENTIFIER|STRING))* ']')?
-	(WHITESPACE '{' modelbinding (',' modelbinding)* '}')?
+	(basemodelitem | modelgroupitem) WHITESPACE+ IDENTIFIER
+	(WHITESPACE+ STRING)?
+	(WHITESPACE+ '<' (IDENTIFIER|STRING) '>')?
+	(WHITESPACE+ '(' IDENTIFIER (',' IDENTIFIER)* ')')? 
+	(WHITESPACE+ '[' (IDENTIFIER|STRING) (',' (IDENTIFIER|STRING))* ']')?
+	(WHITESPACE+ '{' modelbinding (',' modelbinding)* '}')?
 ;
 
 modelgroupitem :
 	'Group' (':' basemodelitem ( ':' modelgroupfunction ('(' (IDENTIFIER|STRING) (',' (IDENTIFIER|STRING))* ')')?)?)?
 ;
 
-itemmodel :
+itemmodelold:
 	(modelitem) (NEWLINE | itemmodel)* EOF
 ;
 
-basemodelitem :
-	'Switch' | 'Rollershutter' | 'String' | 'Dimmer' | 'Contact' | 'DateTime' | 'Color' | 'Player' | 'Location' | 'Call' | 'Image' | ('Number' (':' IDENTIFIER)?)
+itemmodel :
+	(NEWLINE* modelitem (NEWLINE | itemmodel)*) EOF
 ;
 
-modelgroupfunction :
-	'EQUAL' 
+basemodelitem 
+	: 'Switch' 
+	| 'Rollershutter' 
+	| 'String' 
+	| 'Dimmer' 
+	| 'Contact' 
+	| 'DateTime' 
+	| 'Color' 
+	| 'Player' 
+	| 'Location' 
+	| 'Call' 
+	| 'Image' 
+	| ('Number' (':' IDENTIFIER)?)
+;
+
+modelgroupfunction 
+	: 'EQUAL' 
 	| 'AND' '(' (valuetype | IDENTIFIER) ',' (valuetype | IDENTIFIER)  ')' 
 	| 'OR' '(' (valuetype | IDENTIFIER) ',' (valuetype | IDENTIFIER)  ')'
 	| 'NAND' '(' (valuetype | IDENTIFIER) ',' (valuetype | IDENTIFIER)  ')'

--- a/Items.g4
+++ b/Items.g4
@@ -13,10 +13,6 @@ modelgroupitem :
 	'Group' (':' basemodelitem ( ':' modelgroupfunction ('(' (IDENTIFIER|STRING) (',' (IDENTIFIER|STRING))* ')')?)?)?
 ;
 
-itemmodelold:
-	(modelitem) (NEWLINE | itemmodel)* EOF
-;
-
 itemmodel :
 	(NEWLINE* modelitem (NEWLINE | itemmodel)*) EOF
 ;

--- a/README.md
+++ b/README.md
@@ -13,9 +13,8 @@ buildGrammar then creates the JS parser and lexer files that are needed to parse
 The tests contain some samples to validate text input for .items file from openhab.
 
 TODO:
- - be more generous with WHITESPACEs: "Group s" is valid, but "Group&nbsp;&nbsp;&nbsp;&nbsp;s" not currently.
  - comments do not seem to work
- - better validation at binding params (e.g. this is currently possible but shouzld not be valid:  {channel="homematic:..."})
+ - better validation at binding params (e.g. this is currently possible but should not be valid:  {channel="homematic:..."})
 
  Samples of currently working items:
 ```String Livingroom_Light_Connection "Livingroom Ceiling Light [MAP(error.map):%s]" <myerror>
@@ -43,4 +42,4 @@ Group:Switch:MIN e "label" <icon> (otherGroup)
 Group:Switch:SUM e "label" <icon> (otherGroup)
 ```
 
-Newlines inbetween also work, only newline as first element is not possible right now.
+Newlines inbetween also work.

--- a/__resources__/resources.js
+++ b/__resources__/resources.js
@@ -20,26 +20,36 @@ Group:Switch:MIN e "label" <icon> (otherGroup)
 Group:Switch:SUM e "label" <icon> (otherGroup)`
 
 // taken from openhab docs about items
-const complexItems = `String Livingroom_Light_Connection "Livingroom Ceiling Light [MAP(error.map):%s]" <myerror>
+const complexItems = `
+
+String     Livingroom_Light_Connection "Livingroom Ceiling Light [MAP(error.map):%s]" <myerror>
 Switch Livingroom_Light "Livingroom Ceiling Light" <myswitch>
-Contact Livingroom_Window "Ventana del salón [MAP(window_esp.map):%s]"
+
+
+
+
+Contact Livingroom_Window     "Ventana del salón [MAP(window_esp.map):%s]"
 Switch Livingroom_Light "Livingroom Ceiling Light" <switch>
-Number Livingroom_Temperature "Temperature [%.1f °C]"
-String Livingroom_TV_Channel "Now Playing [%s]"
-DateTime Livingroom_TV_LastUpdate "Last Update [%1$ta %1$tR]"
+Number Livingroom_Temperature   "Temperature [%.1f °C]"
+
+String     Livingroom_TV_Channel "Now Playing [%s]"
+DateTime     Livingroom_TV_LastUpdate     "Last Update [%1$ta %1$tR]"
 Number Livingroom_Clock_Battery "Battery Charge [%d %%]"
 Location My_Location "My Location [%2$s°N %3$s°E %1$sm]"
+
 Number Livingroom_Temperature "Temperature [%.1f °C]"
 String Bedroom_Sonos_CurrentTitle "Title [%s]" (gBedRoom) {channel="sonos:..."}
 Number Bathroom_WaschingMachine_Power "Power [%.0f W]" <energy> (gPower) {channel="homematic:..."}
-Number Livingroom_Temperature "Temperature [%.1f °C]" <temperature> (gTemperature,gLivingroom) ["TargetTemperature"] {knx="1/0/15+0/0/15"}
+Number      Livingroom_Temperature "Temperature [%.1f °C]"     <temperature>     (gTemperature,gLivingroom)    ["TargetTemperature"]      {knx="1/0/15+0/0/15"}
+
+
+
 `
 
 // TODO
 // Switch Kitchen_Light "Kitchen Light" {mqtt="<[...], >[...]" }
 
-
 module.exports = {
- groupsWithFunctions,
- complexItems
+  groupsWithFunctions,
+  complexItems
 }

--- a/__tests__/groups.test.js
+++ b/__tests__/groups.test.js
@@ -63,7 +63,7 @@ describe('Error cases', () => {
         column: 0,
         row: 0,
         text:
-          "mismatched input 'Gro1up' expecting {'Group', 'Switch', 'Rollershutter', 'String', 'Dimmer', 'Contact', 'DateTime', 'Color', 'Player', 'Location', 'Call', 'Image', 'Number'}",
+          "mismatched input 'Gro1up' expecting {'Group', 'Switch', 'Rollershutter', 'String', 'Dimmer', 'Contact', 'DateTime', 'Color', 'Player', 'Location', 'Call', 'Image', 'Number', NEWLINE}",
         type: 'error'
       }
     ])
@@ -71,52 +71,95 @@ describe('Error cases', () => {
 
   test('Group without WHITESPACE + IDENTIFIER', () => {
     expect(parse('Group')).toEqual([
-      { column: 5, row: 0, text: "mismatched input '<EOF>' expecting WHITESPACE", type: 'error' }
+      {
+        column: 5,
+        row: 0,
+        text: "mismatched input '<EOF>' expecting WHITESPACE",
+        type: 'error'
+      }
     ])
   })
 
   test('Group without IDENTIFIER', () => {
-    expect(parse('Group ')).toEqual([{ column: 6, row: 0, text: "missing IDENTIFIER at '<EOF>'", type: 'error' }])
+    expect(parse('Group ')).toEqual([
+      {
+        column: 6,
+        row: 0,
+        text: "extraneous input '<EOF>' expecting {IDENTIFIER, WHITESPACE}",
+        type: 'error'
+      }
+    ])
   })
 
   test('label missing ""', () => {
     // TODO improve grammar to get a better error message here
     expect(parse('Group group1 group1')).toEqual([
-      { column: 13, row: 0, text: "no viable alternative at input ' group1'", type: 'error' }
+      {
+        column: 13,
+        row: 0,
+        text: "no viable alternative at input ' group1'",
+        type: 'error'
+      }
     ])
   })
 
   test('label mixing " and \'', () => {
     // TODO improve grammar to get a better error message here
     expect(parse('Group group1 "group1\'')).toEqual([
-      { column: 13, row: 0, text: "no viable alternative at input ' \"'", type: 'error' }
+      {
+        column: 13,
+        row: 0,
+        text: "no viable alternative at input ' \"'",
+        type: 'error'
+      }
     ])
   })
 
   test('label mixing \' and "', () => {
     // TODO improve grammar to get a better error message here
     expect(parse('Group group1 \'group1"')).toEqual([
-      { column: 13, row: 0, text: "no viable alternative at input ' ''", type: 'error' }
+      {
+        column: 13,
+        row: 0,
+        text: "no viable alternative at input ' ''",
+        type: 'error'
+      }
     ])
   })
 
   test('with missing " behind label', () => {
     // TODO improve grammar to get a better error message here
     expect(parse('Group group1 "group1')).toEqual([
-      { column: 13, row: 0, text: "no viable alternative at input ' \"'", type: 'error' }
+      {
+        column: 13,
+        row: 0,
+        text: "no viable alternative at input ' \"'",
+        type: 'error'
+      }
     ])
   })
 
   test('with missing " before label', () => {
     // TODO improve grammar to get a better error message here
     expect(parse('Group group1 group1"')).toEqual([
-      { column: 13, row: 0, text: "no viable alternative at input ' group1'", type: 'error' }
+      {
+        column: 13,
+        row: 0,
+        text: "no viable alternative at input ' group1'",
+        type: 'error'
+      }
     ])
   })
 
   test('with label but no name', () => {
     expect(parse('Group "group1"')).toEqual([
-      { column: 6, row: 0, text: 'mismatched input \'"group1"\' expecting IDENTIFIER', type: 'error' }
+      {
+        column: 6,
+        row: 0,
+        text:
+          'extraneous input \'"group1"\' expecting {IDENTIFIER, WHITESPACE}',
+        type: 'error'
+      }
     ])
   })
 
@@ -142,7 +185,12 @@ describe('Error cases', () => {
   test('missing "<" at icon', () => {
     // TODO improve grammar to get a better error message here
     expect(parse('Group identifier "label" icon>')).toEqual([
-      { column: 25, row: 0, text: "no viable alternative at input ' icon'", type: 'error' }
+      {
+        column: 25,
+        row: 0,
+        text: "no viable alternative at input ' icon'",
+        type: 'error'
+      }
     ])
   })
 
@@ -162,19 +210,36 @@ describe('Error cases', () => {
   test('missing "(" before nested group', () => {
     // TODO improve grammar to get a better error message here
     expect(parse('Group identifier "label" <icon> otherGroup)')).toEqual([
-      { column: 32, row: 0, text: "no viable alternative at input ' otherGroup'", type: 'error' }
+      {
+        column: 32,
+        row: 0,
+        text: "no viable alternative at input ' otherGroup'",
+        type: 'error'
+      }
     ])
   })
 
   test('missing ")" after nested group', () => {
     expect(parse('Group identifier "label" <icon> (otherGroup')).toEqual([
-      { column: 43, row: 0, text: "mismatched input '<EOF>' expecting {',', ')'}", type: 'error' }
+      {
+        column: 43,
+        row: 0,
+        text: "mismatched input '<EOF>' expecting {',', ')'}",
+        type: 'error'
+      }
     ])
   })
 
   test('nested groups without ","', () => {
-    expect(parse('Group identifier "label" <icon> (otherGroup otherGroup2)')).toEqual([
-      { column: 43, row: 0, text: "mismatched input ' ' expecting {',', ')'}", type: 'error' }
+    expect(
+      parse('Group identifier "label" <icon> (otherGroup otherGroup2)')
+    ).toEqual([
+      {
+        column: 43,
+        row: 0,
+        text: "mismatched input ' ' expecting {',', ')'}",
+        type: 'error'
+      }
     ])
   })
 
@@ -200,7 +265,12 @@ describe('Error cases', () => {
           "mismatched input 'Number' expecting {'EQUAL', 'AND', 'OR', 'NAND', 'NOR', 'AVG', 'SUM', 'MAX', 'MIN', 'COUNT', 'LATEST', 'EARLIEST'}",
         type: 'error'
       },
-      { column: 19, row: 0, text: "mismatched input '<EOF>' expecting WHITESPACE", type: 'error' }
+      {
+        column: 19,
+        row: 0,
+        text: "mismatched input '<EOF>' expecting WHITESPACE",
+        type: 'error'
+      }
     ])
   })
 
@@ -221,19 +291,34 @@ describe('Error cases', () => {
           "mismatched input 'Number' expecting {'EQUAL', 'AND', 'OR', 'NAND', 'NOR', 'AVG', 'SUM', 'MAX', 'MIN', 'COUNT', 'LATEST', 'EARLIEST'}",
         type: 'error'
       },
-      { column: 20, row: 0, text: "mismatched input '<EOF>' expecting WHITESPACE", type: 'error' }
+      {
+        column: 20,
+        row: 0,
+        text: "mismatched input '<EOF>' expecting WHITESPACE",
+        type: 'error'
+      }
     ])
   })
 
   test('with itemtype + function + missing WHITESPACE', () => {
     expect(parse('Group:Switch:AVG')).toEqual([
-      { column: 16, row: 0, text: "mismatched input '<EOF>' expecting WHITESPACE", type: 'error' }
+      {
+        column: 16,
+        row: 0,
+        text: "mismatched input '<EOF>' expecting WHITESPACE",
+        type: 'error'
+      }
     ])
   })
 
   test('with itemtype + function + missing "("', () => {
     expect(parse('Group:Switch:AND')).toEqual([
-      { column: 16, row: 0, text: "mismatched input '<EOF>' expecting '('", type: 'error' }
+      {
+        column: 16,
+        row: 0,
+        text: "mismatched input '<EOF>' expecting '('",
+        type: 'error'
+      }
     ])
   })
 
@@ -243,7 +328,8 @@ describe('Error cases', () => {
       {
         column: 17,
         row: 0,
-        text: "mismatched input ')' expecting {IDENTIFIER, BOOLEAN, NUMBER, STRING}",
+        text:
+          "mismatched input ')' expecting {IDENTIFIER, BOOLEAN, NUMBER, STRING}",
         type: 'error'
       }
     ])
@@ -252,7 +338,12 @@ describe('Error cases', () => {
   test('with itemtype + function + only one value in ()', () => {
     // TODO this was not in the original grammar, check if types are correct
     expect(parse('Group:Switch:AND(value1)')).toEqual([
-      { column: 23, row: 0, text: "mismatched input ')' expecting ','", type: 'error' }
+      {
+        column: 23,
+        row: 0,
+        text: "mismatched input ')' expecting ','",
+        type: 'error'
+      }
     ])
   })
 
@@ -260,7 +351,12 @@ describe('Error cases', () => {
     // TODO this was not in the original grammar, check if types are correct
     // TODO adapt grammar to show better error?
     expect(parse('Group:Switch:AND(value1 value2)')).toEqual([
-      { column: 23, row: 0, text: "mismatched input ' ' expecting ','", type: 'error' },
+      {
+        column: 23,
+        row: 0,
+        text: "mismatched input ' ' expecting ','",
+        type: 'error'
+      },
       {
         column: 30,
         row: 0,
@@ -274,7 +370,12 @@ describe('Error cases', () => {
   test('with itemtype + function + only one value in ()', () => {
     // TODO this was not in the original grammar, check if types are correct
     expect(parse('Group:Switch:AND(value1,value2)')).toEqual([
-      { column: 31, row: 0, text: "mismatched input '<EOF>' expecting WHITESPACE", type: 'error' }
+      {
+        column: 31,
+        row: 0,
+        text: "mismatched input '<EOF>' expecting WHITESPACE",
+        type: 'error'
+      }
     ])
   })
 })

--- a/__tests__/items.test.js
+++ b/__tests__/items.test.js
@@ -4,7 +4,7 @@ const { complexItems } = require('../__resources__/resources')
 describe('Tests for parsing items from .items files', () => {
   test('Simple item', () => {
     // empty array means there are no errors
-    expect(parse('Switch s1')).toEqual([])
+    expect(parse('Switch  s1')).toEqual([])
   })
 
   test('Simple item with error', () => {

--- a/__tests__/items.test.js
+++ b/__tests__/items.test.js
@@ -1,7 +1,6 @@
 const { parse } = require('../src/index')
 const { complexItems } = require('../__resources__/resources')
 
-
 describe('Tests for parsing items from .items files', () => {
   test('Simple item', () => {
     // empty array means there are no errors
@@ -9,13 +8,12 @@ describe('Tests for parsing items from .items files', () => {
   })
 
   test('Simple item with error', () => {
-    // empty array means there are no errors
     expect(parse('Swi1tch s1')).toEqual([
       {
         column: 0,
         row: 0,
         text:
-          "mismatched input 'Swi1tch' expecting {'Group', 'Switch', 'Rollershutter', 'String', 'Dimmer', 'Contact', 'DateTime', 'Color', 'Player', 'Location', 'Call', 'Image', 'Number'}",
+          "mismatched input 'Swi1tch' expecting {'Group', 'Switch', 'Rollershutter', 'String', 'Dimmer', 'Contact', 'DateTime', 'Color', 'Player', 'Location', 'Call', 'Image', 'Number', NEWLINE}",
         type: 'error'
       }
     ])
@@ -42,7 +40,9 @@ describe('Tests for parsing items from .items files', () => {
   })
 
   test('more complex item', () => {
-    const res = parse('Switch switch "My Switch" <switch> (testGroup) ["LIGHTING"]')
+    const res = parse(
+      'Switch switch "My Switch" <switch> (testGroup) ["LIGHTING"]'
+    )
     expect(res).toEqual([])
   })
 

--- a/package.json
+++ b/package.json
@@ -6,15 +6,18 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "antlr4": "^4.7.1",
-    "jest": "^23.6.0"
+    "antlr4": "^4.7.1"
   },
   "devDependencies": {
-    "rimraf": "^2.6.2"
+    "rimraf": "^2.6.2",
+    "jest": "^23.6.0"
   },
   "scripts": {
     "downloadAntlr": "curl -o antlr.jar https://www.antlr.org/download/antlr-4.7.1-complete.jar",
     "buildGrammar": "rimraf ./src/antlr && java -jar antlr.jar -Dlanguage=JavaScript ./Items.g4 -o ./src/antlr/generated-parser",
     "test": "jest --coverage"
+  },
+  "standard": {
+    "env": [ "jest" ]
   }
 }


### PR DESCRIPTION
Now (multiple) newline is possible at beginning, between items and after items. Also more than 1 whitespace is possible now.